### PR TITLE
Update featuretools requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 bokeh>=1.0.2
-dask>=1.0.0
-distributed>=1.25.1
-featuretools>=0.10.1
+featuretools>=0.16.0
 ipython>=5.8.0
 jupyter>=1.0.0
 lightgbm>=2.2.2


### PR DESCRIPTION
Require `featuretools` >= 0.16.0
Remove `dask` and `distributed` from requirements